### PR TITLE
Fix process launcher

### DIFF
--- a/scripts/qap_anatomical_spatial.py
+++ b/scripts/qap_anatomical_spatial.py
@@ -1,8 +1,8 @@
 
 
-def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
-                                      run_name, site_name=None):
-
+def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
+                                          run_name, site_name=None):
+    
     # build pipeline for each subject, individually
 
     # ~ 29 minutes per subject with 1 core to ANTS
@@ -15,7 +15,7 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-
+    
     import glob
     import yaml
 
@@ -24,7 +24,9 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
     from nipype import config as nyconfig
     from nipype import logging
 
+
     logger = logging.getLogger('workflow')
+
 
     sub_id = str(subject_info[0])
 
@@ -38,8 +40,9 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
     else:
         scan_id = "scan_0"
 
+
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name,
+    output_dir = os.path.join(config["output_directory"], run_name, \
                               sub_id, session_id, scan_id)
 
     try:
@@ -52,17 +55,17 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
         else:
             pass
 
-    log_dir = output_dir
 
+    log_dir = output_dir
+   
     # set up logging
-    nyconfig.update_config(
-        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-
+    
     pipeline_start_time = time.time()
 
     logger.info("Pipeline start time: %s" % pipeline_start_stamp)
@@ -71,63 +74,73 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
 
     logger.info("Configuration settings:\n" + str(config))
 
+ 
+ 
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-
+    
     config["run_name"] = run_name
 
     if site_name:
         config["site_name"] = site_name
 
-    # os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = \
+
+    #os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = \
     #    str(config["num_ants_threads"])
+    
+    
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
-                                     session_id)
-
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
+                            session_id)
+                            
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-
+    
+    
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
+    
+        if os.path.isdir(os.path.join(output_dir,resource)) and \
+            resource not in resource_pool.keys():
 
-        if os.path.isdir(os.path.join(output_dir, resource)) and \
-                resource not in resource_pool.keys():
-
-            resource_pool[resource] = glob.glob(os.path.join(output_dir,
-                                                             resource, "*"))[0]
+            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
+                                          resource, "*"))[0]
+                 
 
     # resource pool check
     invalid_paths = []
-
+    
     for resource in resource_pool.keys():
-
+    
         if not os.path.isfile(resource_pool[resource]):
-
+        
             invalid_paths.append((resource, resource_pool[resource]))
-
+            
+            
     if len(invalid_paths) > 0:
-
+        
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-
+        
         for path_tuple in invalid_paths:
-
+        
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-
+                  
         err = err + "\n\n"
-
+        
         raise Exception(err)
-
+                  
+    
+    
     # start connecting the pipeline
-
+       
     if "qap_anatomical_spatial" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_anatomical_spatial_workflow
@@ -135,34 +148,36 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
         workflow, resource_pool = \
             qap_anatomical_spatial_workflow(workflow, resource_pool, config)
 
+    
+
     # set up the datasinks
     new_outputs = 0
-
+    
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-
+    
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource
+            # were not present in the subject list YML (the starting resource 
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-
+    
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-
+    
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-
+            
                 new_outputs += 1
 
     else:
@@ -175,26 +190,29 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-
+    
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-
+            
             new_outputs += 1
+         
+    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
-
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
-                                                      ".dot"),
-                             simple_form=False)
-
-        workflow.run(plugin='MultiProc', plugin_args={
-                     'n_procs': config["num_cores_per_subject"]})
+    
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
+                                                          ".dot"), \
+                                                          simple_form=False)
+        
+        workflow.run(plugin='MultiProc', plugin_args= \
+                         {'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
+
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -208,16 +226,19 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
             print "Couldn\'t remove the working directory!"
             pass
 
-    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
 
+    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
+    
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s"
-                % ((pipeline_end_time - pipeline_start_time) / 60))
+    logger.info("Elapsed time (minutes) since last start: %s" \
+                % ((pipeline_end_time - pipeline_start_time)/60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
+
     return workflow
+
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -227,7 +248,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     import time
 
     from multiprocessing import Process
-
+    
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -255,7 +276,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-
+                            
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -273,14 +294,17 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-
+                        
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
                         flat_sub_dict[sub_info_tuple].update(resource_dict)
 
-    with open(pipeline_config_yaml, "r") as f:
+
+        
+    with open(pipeline_config_yaml,"r") as f:
         config = yaml.load(f)
+                        
 
     try:
         os.makedirs(config["output_directory"])
@@ -292,6 +316,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -302,65 +327,100 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
+    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
-
+        
     if not cloudify:
 
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_anatomical_spatial_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, sites_dict[sub_info[0]]))
-                      for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_anatomical_spatial_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, sites_dict[sub_info[0]])) \
+                                for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_anatomical_spatial_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, None))
-                      for sub_info in flat_sub_dict.keys()]
-
+            procss = [Process(target=build_anatomical_spatial_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, None)) \
+                                for sub_info in flat_sub_dict.keys()]
+                              
+                              
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-
+        
         # Init job queue
         job_queue = []
-        ns_atonce = config.get('num_subjects_at_once', 1)
-
-        # Stream the subject workflows for preprocessing.
-        # At Any time in the pipeline c.numSubjectsAtOnce
-        # will run, unless the number remaining is less than
-        # the value of the parameter stated above
-
-        idx = 0
-        nprocs = len(procss)
-        while idx < nprocs:
-            # Check every job in the queue's status
-            for job in job_queue:
-                # If the job is not alive
-                if not job.is_alive():
-                    # Find job and delete it from queue
-                    logger.info('found dead job: %s' % str(job))
-                    loc = job_queue.index(job)
-                    del job_queue[loc]
-
-            # Check free slots after prunning jobs
-            slots = ns_atonce - len(job_queue)
-
-            if slots > 0:
-                idc = idx
-                for p in procss[idc:idc + slots]:
-                    # ..and start the next available process (subject)
-                    p.start()
-                    print >>pid, p.pid
-                    # Append this to job queue and increment index
-                    job_queue.append(p)
-                    idx += 1
-
-            # Add sleep so while loop isn't consuming 100% of CPU
-            time.sleep(2)
-
+    
+        # If we're allocating more processes than are subjects, run them all
+        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
+        
+            """
+            Stream all the subjects as sublist is
+            less than or equal to the number of 
+            subjects that need to run
+            """
+        
+            for p in procss:
+                p.start()
+                print >>pid,p.pid
+        
+        # Otherwise manage resources to run processes incrementally
+        else:
+        
+            """
+            Stream the subject workflows for preprocessing.
+            At Any time in the pipeline c.numSubjectsAtOnce
+            will run, unless the number remaining is less than
+            the value of the parameter stated above
+            """
+        
+            idx = 0
+        
+            while(idx < len(flat_sub_dict)):
+        
+                # If the job queue is empty and we haven't started indexing
+                if len(job_queue) == 0 and idx == 0:
+        
+                    # Init subject process index
+                    idc = idx
+        
+                    # Launch processes (one for each subject)
+                    for p in procss[idc: idc + config["num_subjects_at_once"]]:
+        
+                        p.start()
+                        print >>pid,p.pid
+                        job_queue.append(p)
+                        idx += 1
+        
+                # Otherwise, jobs are running - check them
+                else:
+        
+                    # Check every job in the queue's status
+                    for job in job_queue:
+        
+                        # If the job is not alive
+                        if not job.is_alive():
+        
+                            # Find job and delete it from queue
+                            print 'found dead job ', job
+                            loc = job_queue.index(job)
+                            del job_queue[loc]
+        
+                            # ...and start the next available process (subject)
+                            procss[idx].start()
+        
+                            # Append this to job queue and increment index
+                            job_queue.append(procss[idx])
+                            idx += 1
+    
+                    # Add sleep so while loop isn't consuming 100% of CPU
+                    time.sleep(2)
+        
         pid.close()
+
 
     else:
 
@@ -376,8 +436,9 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
 
-        build_anatomical_spatial_workflow(subject_list[sub], config, sub,
-                                          run_name, site_name)
+        build_anatomical_spatial_workflow(subject_list[sub], config, sub, \
+                                              run_name, site_name)
+
 
 
 # Main routine
@@ -389,26 +450,30 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
-    cloudgroup.add_argument('--subj_idx', type=int,
-                            help='Subject index to run')
 
-    cloudgroup.add_argument('--s3_dict_yml', type=str,
-                            help='Path to YAML file containing S3 input '
-                            'filepaths dictionary')
+    cloudgroup.add_argument('--subj_idx', type=int, \
+                                help='Subject index to run')
+
+    cloudgroup.add_argument('--s3_dict_yml', type=str, \
+                                help='Path to YAML file containing S3 input '\
+                                     'filepaths dictionary')
+
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str,
-                       help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str, \
+                            help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str,
-                     help="filepath to pipeline configuration YAML")
+    req.add_argument("config", type=str, \
+                            help="filepath to pipeline configuration YAML")
+
 
     args = parser.parse_args()
+
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -442,8 +507,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
-                                       args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
+                                           args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -456,12 +521,17 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
+
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
+
 # Make executable
 if __name__ == "__main__":
     main()
+
+
+

--- a/scripts/qap_anatomical_spatial.py
+++ b/scripts/qap_anatomical_spatial.py
@@ -1,8 +1,8 @@
 
 
-def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
-                                          run_name, site_name=None):
-    
+def build_anatomical_spatial_workflow(resource_pool, config, subject_info,
+                                      run_name, site_name=None):
+
     # build pipeline for each subject, individually
 
     # ~ 29 minutes per subject with 1 core to ANTS
@@ -15,7 +15,7 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-    
+
     import glob
     import yaml
 
@@ -24,9 +24,7 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
     from nipype import config as nyconfig
     from nipype import logging
 
-
     logger = logging.getLogger('workflow')
-
 
     sub_id = str(subject_info[0])
 
@@ -40,9 +38,8 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
     else:
         scan_id = "scan_0"
 
-
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name, \
+    output_dir = os.path.join(config["output_directory"], run_name,
                               sub_id, session_id, scan_id)
 
     try:
@@ -55,17 +52,17 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
         else:
             pass
 
-
     log_dir = output_dir
-   
+
     # set up logging
-    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config(
+        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
+
     pipeline_start_time = time.time()
 
     logger.info("Pipeline start time: %s" % pipeline_start_stamp)
@@ -74,73 +71,63 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
 
     logger.info("Configuration settings:\n" + str(config))
 
- 
- 
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-    
+
     config["run_name"] = run_name
 
     if site_name:
         config["site_name"] = site_name
 
-
-    #os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = \
+    # os.environ['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = \
     #    str(config["num_ants_threads"])
-    
-    
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
-                            session_id)
-                            
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
+                                     session_id)
+
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-    
-    
+
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
-    
-        if os.path.isdir(os.path.join(output_dir,resource)) and \
-            resource not in resource_pool.keys():
 
-            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
-                                          resource, "*"))[0]
-                 
+        if os.path.isdir(os.path.join(output_dir, resource)) and \
+                resource not in resource_pool.keys():
+
+            resource_pool[resource] = glob.glob(os.path.join(output_dir,
+                                                             resource, "*"))[0]
 
     # resource pool check
     invalid_paths = []
-    
+
     for resource in resource_pool.keys():
-    
+
         if not os.path.isfile(resource_pool[resource]):
-        
+
             invalid_paths.append((resource, resource_pool[resource]))
-            
-            
+
     if len(invalid_paths) > 0:
-        
+
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-        
+
         for path_tuple in invalid_paths:
-        
+
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-                  
+
         err = err + "\n\n"
-        
+
         raise Exception(err)
-                  
-    
-    
+
     # start connecting the pipeline
-       
+
     if "qap_anatomical_spatial" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_anatomical_spatial_workflow
@@ -148,36 +135,34 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
         workflow, resource_pool = \
             qap_anatomical_spatial_workflow(workflow, resource_pool, config)
 
-    
-
     # set up the datasinks
     new_outputs = 0
-    
+
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-    
+
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource 
+            # were not present in the subject list YML (the starting resource
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-    
+
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-    
+
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-            
+
                 new_outputs += 1
 
     else:
@@ -190,29 +175,26 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-    
+
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-            
+
             new_outputs += 1
-         
-    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
-    
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
-                                                          ".dot"), \
-                                                          simple_form=False)
-        
-        workflow.run(plugin='MultiProc', plugin_args= \
-                         {'n_procs': config["num_cores_per_subject"]})
+
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
+                                                      ".dot"),
+                             simple_form=False)
+
+        workflow.run(plugin='MultiProc', plugin_args={
+                     'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
-
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -226,19 +208,16 @@ def build_anatomical_spatial_workflow(resource_pool, config, subject_info, \
             print "Couldn\'t remove the working directory!"
             pass
 
-
     pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
+
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s" \
-                % ((pipeline_end_time - pipeline_start_time)/60))
+    logger.info("Elapsed time (minutes) since last start: %s"
+                % ((pipeline_end_time - pipeline_start_time) / 60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
-
     return workflow
-
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -248,7 +227,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     import time
 
     from multiprocessing import Process
-    
+
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -276,7 +255,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-                            
+
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -294,17 +273,14 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-                        
+
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
                         flat_sub_dict[sub_info_tuple].update(resource_dict)
 
-
-        
-    with open(pipeline_config_yaml,"r") as f:
+    with open(pipeline_config_yaml, "r") as f:
         config = yaml.load(f)
-                        
 
     try:
         os.makedirs(config["output_directory"])
@@ -316,7 +292,6 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -327,100 +302,65 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
-    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
-        
+
     if not cloudify:
 
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_anatomical_spatial_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, sites_dict[sub_info[0]])) \
-                                for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_anatomical_spatial_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, sites_dict[sub_info[0]]))
+                      for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_anatomical_spatial_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, None)) \
-                                for sub_info in flat_sub_dict.keys()]
-                              
-                              
+            procss = [Process(target=build_anatomical_spatial_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, None))
+                      for sub_info in flat_sub_dict.keys()]
+
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-        
+
         # Init job queue
         job_queue = []
-    
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-        
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-        
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-        
-        # Otherwise manage resources to run processes incrementally
-        else:
-        
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-        
-            idx = 0
-        
-            while(idx < len(flat_sub_dict)):
-        
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-        
-                    # Init subject process index
-                    idc = idx
-        
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc + config["num_subjects_at_once"]]:
-        
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-        
-                # Otherwise, jobs are running - check them
-                else:
-        
-                    # Check every job in the queue's status
-                    for job in job_queue:
-        
-                        # If the job is not alive
-                        if not job.is_alive():
-        
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-        
-                            # ...and start the next available process (subject)
-                            procss[idx].start()
-        
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
-    
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-        
-        pid.close()
+        ns_atonce = config.get('num_subjects_at_once', 1)
 
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
+
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
+        pid.close()
 
     else:
 
@@ -436,9 +376,8 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
 
-        build_anatomical_spatial_workflow(subject_list[sub], config, sub, \
-                                              run_name, site_name)
-
+        build_anatomical_spatial_workflow(subject_list[sub], config, sub,
+                                          run_name, site_name)
 
 
 # Main routine
@@ -450,30 +389,26 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
+    cloudgroup.add_argument('--subj_idx', type=int,
+                            help='Subject index to run')
 
-    cloudgroup.add_argument('--subj_idx', type=int, \
-                                help='Subject index to run')
-
-    cloudgroup.add_argument('--s3_dict_yml', type=str, \
-                                help='Path to YAML file containing S3 input '\
-                                     'filepaths dictionary')
-
+    cloudgroup.add_argument('--s3_dict_yml', type=str,
+                            help='Path to YAML file containing S3 input '
+                            'filepaths dictionary')
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str, \
-                            help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str,
+                       help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str, \
-                            help="filepath to pipeline configuration YAML")
-
+    req.add_argument("config", type=str,
+                     help="filepath to pipeline configuration YAML")
 
     args = parser.parse_args()
-
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -507,8 +442,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
-                                           args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
+                                       args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -521,17 +456,12 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
-
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
-
 # Make executable
 if __name__ == "__main__":
     main()
-
-
-

--- a/scripts/qap_anatomical_spatial.py
+++ b/scripts/qap_anatomical_spatial.py
@@ -246,9 +246,10 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     import os
     import yaml
     import time
-
     from multiprocessing import Process
-    
+    from nipype import logging
+    logger = logging.getLogger('workflow')
+
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -353,75 +354,43 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         
         # Init job queue
         job_queue = []
-    
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-        
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-        
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-        
-        # Otherwise manage resources to run processes incrementally
-        else:
-        
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-        
-            idx = 0
-        
-            while(idx < len(flat_sub_dict)):
-        
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-        
-                    # Init subject process index
-                    idc = idx
-        
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc + config["num_subjects_at_once"]]:
-        
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-        
-                # Otherwise, jobs are running - check them
-                else:
-        
-                    # Check every job in the queue's status
-                    for job in job_queue:
-        
-                        # If the job is not alive
-                        if not job.is_alive():
-        
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-        
-                            # ...and start the next available process (subject)
-                            procss[idx].start()
-        
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
-    
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-        
+        ns_atonce = config.get('num_subjects_at_once', 1)
+
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
+
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
         pid.close()
-
-
+        
     else:
 
         # run on cloud

--- a/scripts/qap_functional_spatial.py
+++ b/scripts/qap_functional_spatial.py
@@ -1,8 +1,8 @@
 
 
-def build_functional_spatial_workflow(resource_pool, config, subject_info, \
-                                          run_name, site_name=None):
-    
+def build_functional_spatial_workflow(resource_pool, config, subject_info,
+                                      run_name, site_name=None):
+
     # build pipeline for each subject, individually
 
     # ~ 5 min 20 sec per subject
@@ -16,7 +16,7 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-    
+
     import glob
     import yaml
 
@@ -25,9 +25,7 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
     from nipype import config as nyconfig
     from nipype import logging
 
-
     logger = logging.getLogger('workflow')
-
 
     sub_id = str(subject_info[0])
 
@@ -41,9 +39,8 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
     else:
         scan_id = "scan_0"
 
-
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name, \
+    output_dir = os.path.join(config["output_directory"], run_name,
                               sub_id, session_id, scan_id)
 
     try:
@@ -55,17 +52,18 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
             raise Exception(err)
         else:
             pass
-            
+
     log_dir = output_dir
-    
+
     # set up logging
-    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config(
+        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
+
     pipeline_start_time = time.time()
 
     logger.info("Pipeline start time: %s" % pipeline_start_stamp)
@@ -74,69 +72,59 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
 
     logger.info("Configuration settings:\n" + str(config))
 
-       
-       
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-    
-    config["run_name"] = run_name
 
+    config["run_name"] = run_name
 
     if site_name:
         config["site_name"] = site_name
-    
-
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
-                            session_id)
-                            
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
+                                     session_id)
+
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-    
-    
+
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
-    
-        if os.path.isdir(os.path.join(output_dir,resource)) and resource not in resource_pool.keys():
-        
-            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
-                                          resource, "*"))[0]
-                 
+
+        if os.path.isdir(os.path.join(output_dir, resource)) and resource not in resource_pool.keys():
+
+            resource_pool[resource] = glob.glob(os.path.join(output_dir,
+                                                             resource, "*"))[0]
 
     # resource pool check
     invalid_paths = []
-    
+
     for resource in resource_pool.keys():
-    
+
         if not os.path.isfile(resource_pool[resource]):
-        
+
             invalid_paths.append((resource, resource_pool[resource]))
-            
-            
+
     if len(invalid_paths) > 0:
-        
+
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-        
+
         for path_tuple in invalid_paths:
-        
+
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-                  
+
         err = err + "\n\n"
-        
+
         raise Exception(err)
-                  
-    
-    
+
     # start connecting the pipeline
-       
+
     if "qap_functional_spatial" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_functional_spatial_workflow
@@ -144,36 +132,34 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
         workflow, resource_pool = \
             qap_functional_spatial_workflow(workflow, resource_pool, config)
 
-    
-
     # set up the datasinks
     new_outputs = 0
-    
+
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-    
+
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource 
+            # were not present in the subject list YML (the starting resource
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-    
+
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-    
+
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-            
+
                 new_outputs += 1
 
     else:
@@ -186,29 +172,26 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-    
+
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-            
+
             new_outputs += 1
-         
-    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
-    
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
-                                                          ".dot"), \
-                                                          simple_form=False)
-        
-        workflow.run(plugin='MultiProc', plugin_args= \
-                         {'n_procs': config["num_cores_per_subject"]})
+
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
+                                                      ".dot"),
+                             simple_form=False)
+
+        workflow.run(plugin='MultiProc', plugin_args={
+                     'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
-
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -222,21 +205,16 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info, \
             print "Couldn\'t remove the working directory!"
             pass
 
-
-
     pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
+
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s" \
-                % ((pipeline_end_time - pipeline_start_time)/60))
+    logger.info("Elapsed time (minutes) since last start: %s"
+                % ((pipeline_end_time - pipeline_start_time) / 60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
-
-
     return workflow
-
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -246,8 +224,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     from multiprocessing import Process
 
     import time
-    
-    
+
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -275,7 +252,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-                            
+
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -293,12 +270,11 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-                        
+
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
-                        flat_sub_dict[sub_info_tuple].update(resource_dict)                    
-
+                        flat_sub_dict[sub_info_tuple].update(resource_dict)
 
     # in case some subjects have site names and others don't
     if len(sites_dict.keys()) > 0:
@@ -306,10 +282,8 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
             if subid not in sites_dict.keys():
                 sites_dict[subid] = None
 
-
-    with open(pipeline_config_yaml,"r") as f:
+    with open(pipeline_config_yaml, "r") as f:
         config = yaml.load(f)
-
 
     try:
         os.makedirs(config["output_directory"])
@@ -321,7 +295,6 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -332,100 +305,65 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
-    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
 
     if not cloudify:
-        
+
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_functional_spatial_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, sites_dict[sub_info[0]])) \
-                                for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_functional_spatial_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, sites_dict[sub_info[0]]))
+                      for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_functional_spatial_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, None)) \
-                                for sub_info in flat_sub_dict.keys()]
-                          
-                          
+            procss = [Process(target=build_functional_spatial_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, None))
+                      for sub_info in flat_sub_dict.keys()]
+
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-    
+
         # Init job queue
         job_queue = []
+        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-    
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-    
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-    
-        # Otherwise manage resources to run processes incrementally
-        else:
-    
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-    
-            idx = 0
-    
-            while(idx < len(flat_sub_dict)):
-    
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-    
-                    # Init subject process index
-                    idc = idx
-    
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
-    
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-    
-                # Otherwise, jobs are running - check them
-                else:
-    
-                    # Check every job in the queue's status
-                    for job in job_queue:
-    
-                        # If the job is not alive
-                        if not job.is_alive():
-    
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-    
-                            # ..and start the next available process (subject)
-                            procss[idx].start()
-    
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
 
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-    
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
         pid.close()
-
 
     else:
 
@@ -441,9 +379,8 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
 
-        build_functional_spatial_workflow(subject_list[sub], config, sub, \
-                                              run_name, site_name)
-
+        build_functional_spatial_workflow(subject_list[sub], config, sub,
+                                          run_name, site_name)
 
 
 def main():
@@ -454,30 +391,26 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
+    cloudgroup.add_argument('--subj_idx', type=int,
+                            help='Subject index to run')
 
-    cloudgroup.add_argument('--subj_idx', type=int, \
-                                help='Subject index to run')
-
-    cloudgroup.add_argument('--s3_dict_yml', type=str, \
-                                help='Path to YAML file containing S3 input '\
-                                     'filepaths dictionary')
-
+    cloudgroup.add_argument('--s3_dict_yml', type=str,
+                            help='Path to YAML file containing S3 input '
+                            'filepaths dictionary')
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str, \
-                            help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str,
+                       help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str, \
-                            help="filepath to pipeline configuration YAML")
-
+    req.add_argument("config", type=str,
+                     help="filepath to pipeline configuration YAML")
 
     args = parser.parse_args()
-
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -511,8 +444,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
-                                           args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
+                                       args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -525,16 +458,11 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
-
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
-
 if __name__ == "__main__":
     main()
-
-
-

--- a/scripts/qap_functional_spatial.py
+++ b/scripts/qap_functional_spatial.py
@@ -244,8 +244,9 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     import os
     import yaml
     from multiprocessing import Process
-
     import time
+    from nipype import logging
+    logger = logging.getLogger('workflow')
     
     
     if not cloudify:
@@ -358,74 +359,42 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     
         # Init job queue
         job_queue = []
+        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-    
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-    
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-    
-        # Otherwise manage resources to run processes incrementally
-        else:
-    
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-    
-            idx = 0
-    
-            while(idx < len(flat_sub_dict)):
-    
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-    
-                    # Init subject process index
-                    idc = idx
-    
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
-    
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-    
-                # Otherwise, jobs are running - check them
-                else:
-    
-                    # Check every job in the queue's status
-                    for job in job_queue:
-    
-                        # If the job is not alive
-                        if not job.is_alive():
-    
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-    
-                            # ..and start the next available process (subject)
-                            procss[idx].start()
-    
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
 
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-    
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
         pid.close()
-
 
     else:
 

--- a/scripts/qap_functional_spatial.py
+++ b/scripts/qap_functional_spatial.py
@@ -1,8 +1,8 @@
 
 
-def build_functional_spatial_workflow(resource_pool, config, subject_info,
-                                      run_name, site_name=None):
-
+def build_functional_spatial_workflow(resource_pool, config, subject_info, \
+                                          run_name, site_name=None):
+    
     # build pipeline for each subject, individually
 
     # ~ 5 min 20 sec per subject
@@ -16,7 +16,7 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-
+    
     import glob
     import yaml
 
@@ -25,7 +25,9 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
     from nipype import config as nyconfig
     from nipype import logging
 
+
     logger = logging.getLogger('workflow')
+
 
     sub_id = str(subject_info[0])
 
@@ -39,8 +41,9 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
     else:
         scan_id = "scan_0"
 
+
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name,
+    output_dir = os.path.join(config["output_directory"], run_name, \
                               sub_id, session_id, scan_id)
 
     try:
@@ -52,18 +55,17 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
             raise Exception(err)
         else:
             pass
-
+            
     log_dir = output_dir
-
+    
     # set up logging
-    nyconfig.update_config(
-        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-
+    
     pipeline_start_time = time.time()
 
     logger.info("Pipeline start time: %s" % pipeline_start_stamp)
@@ -72,59 +74,69 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
 
     logger.info("Configuration settings:\n" + str(config))
 
+       
+       
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-
+    
     config["run_name"] = run_name
+
 
     if site_name:
         config["site_name"] = site_name
+    
+
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
-                                     session_id)
-
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
+                            session_id)
+                            
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-
+    
+    
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
-
-        if os.path.isdir(os.path.join(output_dir, resource)) and resource not in resource_pool.keys():
-
-            resource_pool[resource] = glob.glob(os.path.join(output_dir,
-                                                             resource, "*"))[0]
+    
+        if os.path.isdir(os.path.join(output_dir,resource)) and resource not in resource_pool.keys():
+        
+            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
+                                          resource, "*"))[0]
+                 
 
     # resource pool check
     invalid_paths = []
-
+    
     for resource in resource_pool.keys():
-
+    
         if not os.path.isfile(resource_pool[resource]):
-
+        
             invalid_paths.append((resource, resource_pool[resource]))
-
+            
+            
     if len(invalid_paths) > 0:
-
+        
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-
+        
         for path_tuple in invalid_paths:
-
+        
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-
+                  
         err = err + "\n\n"
-
+        
         raise Exception(err)
-
+                  
+    
+    
     # start connecting the pipeline
-
+       
     if "qap_functional_spatial" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_functional_spatial_workflow
@@ -132,34 +144,36 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
         workflow, resource_pool = \
             qap_functional_spatial_workflow(workflow, resource_pool, config)
 
+    
+
     # set up the datasinks
     new_outputs = 0
-
+    
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-
+    
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource
+            # were not present in the subject list YML (the starting resource 
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-
+    
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-
+    
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-
+            
                 new_outputs += 1
 
     else:
@@ -172,26 +186,29 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-
+    
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-
+            
             new_outputs += 1
+         
+    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
-
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
-                                                      ".dot"),
-                             simple_form=False)
-
-        workflow.run(plugin='MultiProc', plugin_args={
-                     'n_procs': config["num_cores_per_subject"]})
+    
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
+                                                          ".dot"), \
+                                                          simple_form=False)
+        
+        workflow.run(plugin='MultiProc', plugin_args= \
+                         {'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
+
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -205,16 +222,21 @@ def build_functional_spatial_workflow(resource_pool, config, subject_info,
             print "Couldn\'t remove the working directory!"
             pass
 
-    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
 
+
+    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
+    
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s"
-                % ((pipeline_end_time - pipeline_start_time) / 60))
+    logger.info("Elapsed time (minutes) since last start: %s" \
+                % ((pipeline_end_time - pipeline_start_time)/60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
+
+
     return workflow
+
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -224,7 +246,8 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     from multiprocessing import Process
 
     import time
-
+    
+    
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -252,7 +275,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-
+                            
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -270,11 +293,12 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-
+                        
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
-                        flat_sub_dict[sub_info_tuple].update(resource_dict)
+                        flat_sub_dict[sub_info_tuple].update(resource_dict)                    
+
 
     # in case some subjects have site names and others don't
     if len(sites_dict.keys()) > 0:
@@ -282,8 +306,10 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
             if subid not in sites_dict.keys():
                 sites_dict[subid] = None
 
-    with open(pipeline_config_yaml, "r") as f:
+
+    with open(pipeline_config_yaml,"r") as f:
         config = yaml.load(f)
+
 
     try:
         os.makedirs(config["output_directory"])
@@ -295,6 +321,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -305,65 +332,100 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
+    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
 
     if not cloudify:
-
+        
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_functional_spatial_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, sites_dict[sub_info[0]]))
-                      for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_functional_spatial_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, sites_dict[sub_info[0]])) \
+                                for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_functional_spatial_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, None))
-                      for sub_info in flat_sub_dict.keys()]
-
+            procss = [Process(target=build_functional_spatial_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, None)) \
+                                for sub_info in flat_sub_dict.keys()]
+                          
+                          
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-
+    
         # Init job queue
         job_queue = []
-        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # Stream the subject workflows for preprocessing.
-        # At Any time in the pipeline c.numSubjectsAtOnce
-        # will run, unless the number remaining is less than
-        # the value of the parameter stated above
+        # If we're allocating more processes than are subjects, run them all
+        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
+    
+            """
+            Stream all the subjects as sublist is
+            less than or equal to the number of 
+            subjects that need to run
+            """
+    
+            for p in procss:
+                p.start()
+                print >>pid,p.pid
+    
+        # Otherwise manage resources to run processes incrementally
+        else:
+    
+            """
+            Stream the subject workflows for preprocessing.
+            At Any time in the pipeline c.numSubjectsAtOnce
+            will run, unless the number remaining is less than
+            the value of the parameter stated above
+            """
+    
+            idx = 0
+    
+            while(idx < len(flat_sub_dict)):
+    
+                # If the job queue is empty and we haven't started indexing
+                if len(job_queue) == 0 and idx == 0:
+    
+                    # Init subject process index
+                    idc = idx
+    
+                    # Launch processes (one for each subject)
+                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
+    
+                        p.start()
+                        print >>pid,p.pid
+                        job_queue.append(p)
+                        idx += 1
+    
+                # Otherwise, jobs are running - check them
+                else:
+    
+                    # Check every job in the queue's status
+                    for job in job_queue:
+    
+                        # If the job is not alive
+                        if not job.is_alive():
+    
+                            # Find job and delete it from queue
+                            print 'found dead job ', job
+                            loc = job_queue.index(job)
+                            del job_queue[loc]
+    
+                            # ..and start the next available process (subject)
+                            procss[idx].start()
+    
+                            # Append this to job queue and increment index
+                            job_queue.append(procss[idx])
+                            idx += 1
 
-        idx = 0
-        nprocs = len(procss)
-        while idx < nprocs:
-            # Check every job in the queue's status
-            for job in job_queue:
-                # If the job is not alive
-                if not job.is_alive():
-                    # Find job and delete it from queue
-                    logger.info('found dead job: %s' % str(job))
-                    loc = job_queue.index(job)
-                    del job_queue[loc]
-
-            # Check free slots after prunning jobs
-            slots = ns_atonce - len(job_queue)
-
-            if slots > 0:
-                idc = idx
-                for p in procss[idc:idc + slots]:
-                    # ..and start the next available process (subject)
-                    p.start()
-                    print >>pid, p.pid
-                    # Append this to job queue and increment index
-                    job_queue.append(p)
-                    idx += 1
-
-            # Add sleep so while loop isn't consuming 100% of CPU
-            time.sleep(2)
-
+                    # Add sleep so while loop isn't consuming 100% of CPU
+                    time.sleep(2)
+    
         pid.close()
+
 
     else:
 
@@ -379,8 +441,9 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
 
-        build_functional_spatial_workflow(subject_list[sub], config, sub,
-                                          run_name, site_name)
+        build_functional_spatial_workflow(subject_list[sub], config, sub, \
+                                              run_name, site_name)
+
 
 
 def main():
@@ -391,26 +454,30 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
-    cloudgroup.add_argument('--subj_idx', type=int,
-                            help='Subject index to run')
 
-    cloudgroup.add_argument('--s3_dict_yml', type=str,
-                            help='Path to YAML file containing S3 input '
-                            'filepaths dictionary')
+    cloudgroup.add_argument('--subj_idx', type=int, \
+                                help='Subject index to run')
+
+    cloudgroup.add_argument('--s3_dict_yml', type=str, \
+                                help='Path to YAML file containing S3 input '\
+                                     'filepaths dictionary')
+
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str,
-                       help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str, \
+                            help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str,
-                     help="filepath to pipeline configuration YAML")
+    req.add_argument("config", type=str, \
+                            help="filepath to pipeline configuration YAML")
+
 
     args = parser.parse_args()
+
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -444,8 +511,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
-                                       args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
+                                           args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -458,11 +525,16 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
+
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
+
 if __name__ == "__main__":
     main()
+
+
+

--- a/scripts/qap_functional_temporal.py
+++ b/scripts/qap_functional_temporal.py
@@ -1,8 +1,8 @@
 
 
-def build_functional_temporal_workflow(resource_pool, config, subject_info, \
-                                           run_name, site_name=None):
-    
+def build_functional_temporal_workflow(resource_pool, config, subject_info,
+                                       run_name, site_name=None):
+
     # build pipeline for each subject, individually
 
     # ~ 5 min 45 sec per subject
@@ -16,7 +16,7 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-    
+
     import glob
     import yaml
 
@@ -25,9 +25,7 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
     from nipype import config as nyconfig
     from nipype import logging
 
-
     logger = logging.getLogger('workflow')
-
 
     sub_id = str(subject_info[0])
 
@@ -41,9 +39,8 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
     else:
         scan_id = "scan_0"
 
-
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name, \
+    output_dir = os.path.join(config["output_directory"], run_name,
                               sub_id, session_id, scan_id)
 
     try:
@@ -56,19 +53,18 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
         else:
             pass
 
-
     log_dir = output_dir
-   
+
     # set up logging
-    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config(
+        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
-    pipeline_start_time = time.time()
 
+    pipeline_start_time = time.time()
 
     logger.info(pipeline_start_stamp)
 
@@ -76,69 +72,59 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
 
     logger.info("Configuration settings:\n" + str(config))
 
-
-        
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-    
-    config["run_name"] = run_name
 
+    config["run_name"] = run_name
 
     if site_name:
         config["site_name"] = site_name
-    
-    
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
-                            session_id)
-                            
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
+                                     session_id)
+
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-    
-    
+
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
-    
-        if os.path.isdir(os.path.join(output_dir,resource)) and resource not in resource_pool.keys():
-        
-            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
-                                          resource, "*"))[0]
-                 
+
+        if os.path.isdir(os.path.join(output_dir, resource)) and resource not in resource_pool.keys():
+
+            resource_pool[resource] = glob.glob(os.path.join(output_dir,
+                                                             resource, "*"))[0]
 
     # resource pool check
     invalid_paths = []
-    
+
     for resource in resource_pool.keys():
-    
+
         if not os.path.isfile(resource_pool[resource]):
-        
+
             invalid_paths.append((resource, resource_pool[resource]))
-            
-            
+
     if len(invalid_paths) > 0:
-        
+
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-        
+
         for path_tuple in invalid_paths:
-        
+
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-                  
+
         err = err + "\n\n"
-        
+
         raise Exception(err)
-                  
-    
-    
+
     # start connecting the pipeline
-       
+
     if "qap_functional_temporal" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_functional_temporal_workflow
@@ -146,36 +132,34 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
         workflow, resource_pool = \
             qap_functional_temporal_workflow(workflow, resource_pool, config)
 
-    
-
     # set up the datasinks
     new_outputs = 0
-    
+
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-    
+
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource 
+            # were not present in the subject list YML (the starting resource
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-    
+
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-    
+
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-            
+
                 new_outputs += 1
 
     else:
@@ -188,29 +172,26 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-    
+
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-            
+
             new_outputs += 1
-         
-    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
-    
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
-                                                          ".dot"), \
-                                                          simple_form=False)
 
-        workflow.run(plugin='MultiProc', plugin_args= \
-                         {'n_procs': config["num_cores_per_subject"]})
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
+                                                      ".dot"),
+                             simple_form=False)
+
+        workflow.run(plugin='MultiProc', plugin_args={
+                     'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
-
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -224,20 +205,16 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info, \
             print "Couldn\'t remove the working directory!"
             pass
 
-
     pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-    
+
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s" \
-                % ((pipeline_end_time - pipeline_start_time)/60))
+    logger.info("Elapsed time (minutes) since last start: %s"
+                % ((pipeline_end_time - pipeline_start_time) / 60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
-
-
     return workflow
-
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -247,8 +224,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     from multiprocessing import Process
 
     import time
-    
-    
+
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -276,7 +252,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-                            
+
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -294,16 +270,14 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-                        
+
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
-                        flat_sub_dict[sub_info_tuple].update(resource_dict)                
+                        flat_sub_dict[sub_info_tuple].update(resource_dict)
 
-        
-    with open(pipeline_config_yaml,"r") as f:
+    with open(pipeline_config_yaml, "r") as f:
         config = yaml.load(f)
-
 
     try:
         os.makedirs(config["output_directory"])
@@ -315,7 +289,6 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -326,100 +299,65 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
-
-    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
 
     if not cloudify:
-        
+
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_functional_temporal_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, sites_dict[sub_info[0]])) \
-                                for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_functional_temporal_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, sites_dict[sub_info[0]]))
+                      for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_functional_temporal_workflow, \
-                            args=(flat_sub_dict[sub_info], config, sub_info, \
-                                      run_name, None)) \
-                                for sub_info in flat_sub_dict.keys()]
-                          
-                          
+            procss = [Process(target=build_functional_temporal_workflow,
+                              args=(flat_sub_dict[sub_info], config, sub_info,
+                                    run_name, None))
+                      for sub_info in flat_sub_dict.keys()]
+
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-    
+
         # Init job queue
         job_queue = []
+        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-    
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-    
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-    
-        # Otherwise manage resources to run processes incrementally
-        else:
-    
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-    
-            idx = 0
-    
-            while(idx < len(flat_sub_dict)):
-    
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-    
-                    # Init subject process index
-                    idc = idx
-    
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
-    
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-    
-                # Otherwise, jobs are running - check them
-                else:
-    
-                    # Check every job in the queue's status
-                    for job in job_queue:
-    
-                        # If the job is not alive
-                        if not job.is_alive():
-    
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-    
-                            # ..and start the next available process (subject)
-                            procss[idx].start()
-    
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
 
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-    
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
         pid.close()
-
 
     else:
 
@@ -434,10 +372,9 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
 
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
-        
-        build_functional_temporal_workflow(subject_list[sub], config, sub, \
-                                               run_name, site_name)
 
+        build_functional_temporal_workflow(subject_list[sub], config, sub,
+                                           run_name, site_name)
 
 
 def main():
@@ -448,30 +385,26 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
+    cloudgroup.add_argument('--subj_idx', type=int,
+                            help='Subject index to run')
 
-    cloudgroup.add_argument('--subj_idx', type=int, \
-                                help='Subject index to run')
-
-    cloudgroup.add_argument('--s3_dict_yml', type=str, \
-                                help='Path to YAML file containing S3 input '\
-                                     'filepaths dictionary')
-
+    cloudgroup.add_argument('--s3_dict_yml', type=str,
+                            help='Path to YAML file containing S3 input '
+                            'filepaths dictionary')
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str, \
-                            help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str,
+                       help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str, \
-                            help="filepath to pipeline configuration YAML")
-
+    req.add_argument("config", type=str,
+                     help="filepath to pipeline configuration YAML")
 
     args = parser.parse_args()
-
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -505,8 +438,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
-                                           args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
+                                       args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -519,16 +452,11 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
-
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
-
 if __name__ == "__main__":
     main()
-
-
-    

--- a/scripts/qap_functional_temporal.py
+++ b/scripts/qap_functional_temporal.py
@@ -245,8 +245,9 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     import os
     import yaml
     from multiprocessing import Process
-
     import time
+    from nipype import logging
+    logger = logging.getLogger('workflow')
     
     
     if not cloudify:
@@ -352,74 +353,42 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     
         # Init job queue
         job_queue = []
+        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # If we're allocating more processes than are subjects, run them all
-        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
-    
-            """
-            Stream all the subjects as sublist is
-            less than or equal to the number of 
-            subjects that need to run
-            """
-    
-            for p in procss:
-                p.start()
-                print >>pid,p.pid
-    
-        # Otherwise manage resources to run processes incrementally
-        else:
-    
-            """
-            Stream the subject workflows for preprocessing.
-            At Any time in the pipeline c.numSubjectsAtOnce
-            will run, unless the number remaining is less than
-            the value of the parameter stated above
-            """
-    
-            idx = 0
-    
-            while(idx < len(flat_sub_dict)):
-    
-                # If the job queue is empty and we haven't started indexing
-                if len(job_queue) == 0 and idx == 0:
-    
-                    # Init subject process index
-                    idc = idx
-    
-                    # Launch processes (one for each subject)
-                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
-    
-                        p.start()
-                        print >>pid,p.pid
-                        job_queue.append(p)
-                        idx += 1
-    
-                # Otherwise, jobs are running - check them
-                else:
-    
-                    # Check every job in the queue's status
-                    for job in job_queue:
-    
-                        # If the job is not alive
-                        if not job.is_alive():
-    
-                            # Find job and delete it from queue
-                            print 'found dead job ', job
-                            loc = job_queue.index(job)
-                            del job_queue[loc]
-    
-                            # ..and start the next available process (subject)
-                            procss[idx].start()
-    
-                            # Append this to job queue and increment index
-                            job_queue.append(procss[idx])
-                            idx += 1
+        # Stream the subject workflows for preprocessing.
+        # At Any time in the pipeline c.numSubjectsAtOnce
+        # will run, unless the number remaining is less than
+        # the value of the parameter stated above
 
-                    # Add sleep so while loop isn't consuming 100% of CPU
-                    time.sleep(2)
-    
+        idx = 0
+        nprocs = len(procss)
+        while idx < nprocs:
+            # Check every job in the queue's status
+            for job in job_queue:
+                # If the job is not alive
+                if not job.is_alive():
+                    # Find job and delete it from queue
+                    logger.info('found dead job: %s' % str(job))
+                    loc = job_queue.index(job)
+                    del job_queue[loc]
+
+            # Check free slots after prunning jobs
+            slots = ns_atonce - len(job_queue)
+
+            if slots > 0:
+                idc = idx
+                for p in procss[idc:idc + slots]:
+                    # ..and start the next available process (subject)
+                    p.start()
+                    print >>pid, p.pid
+                    # Append this to job queue and increment index
+                    job_queue.append(p)
+                    idx += 1
+
+            # Add sleep so while loop isn't consuming 100% of CPU
+            time.sleep(2)
+
         pid.close()
-
 
     else:
 

--- a/scripts/qap_functional_temporal.py
+++ b/scripts/qap_functional_temporal.py
@@ -1,8 +1,8 @@
 
 
-def build_functional_temporal_workflow(resource_pool, config, subject_info,
-                                       run_name, site_name=None):
-
+def build_functional_temporal_workflow(resource_pool, config, subject_info, \
+                                           run_name, site_name=None):
+    
     # build pipeline for each subject, individually
 
     # ~ 5 min 45 sec per subject
@@ -16,7 +16,7 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
 
     import nipype.interfaces.utility as util
     import nipype.interfaces.fsl.maths as fsl
-
+    
     import glob
     import yaml
 
@@ -25,7 +25,9 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
     from nipype import config as nyconfig
     from nipype import logging
 
+
     logger = logging.getLogger('workflow')
+
 
     sub_id = str(subject_info[0])
 
@@ -39,8 +41,9 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
     else:
         scan_id = "scan_0"
 
+
     # define and create the output directory
-    output_dir = os.path.join(config["output_directory"], run_name,
+    output_dir = os.path.join(config["output_directory"], run_name, \
                               sub_id, session_id, scan_id)
 
     try:
@@ -53,18 +56,19 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
         else:
             pass
 
-    log_dir = output_dir
 
+    log_dir = output_dir
+   
     # set up logging
-    nyconfig.update_config(
-        {'logging': {'log_directory': log_dir, 'log_to_file': True}})
+    nyconfig.update_config({'logging': {'log_directory': log_dir, 'log_to_file': True}})
     logging.update_logging(nyconfig)
 
     # take date+time stamp for run identification purposes
     unique_pipeline_id = strftime("%Y%m%d%H%M%S")
     pipeline_start_stamp = strftime("%Y-%m-%d_%H:%M:%S")
-
+    
     pipeline_start_time = time.time()
+
 
     logger.info(pipeline_start_stamp)
 
@@ -72,59 +76,69 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
 
     logger.info("Configuration settings:\n" + str(config))
 
+
+        
     # for QAP spreadsheet generation only
     config["subject_id"] = sub_id
 
     config["session_id"] = session_id
 
     config["scan_id"] = scan_id
-
+    
     config["run_name"] = run_name
+
 
     if site_name:
         config["site_name"] = site_name
+    
+    
 
     workflow = pe.Workflow(name=scan_id)
 
-    workflow.base_dir = os.path.join(config["working_directory"], sub_id,
-                                     session_id)
-
+    workflow.base_dir = os.path.join(config["working_directory"], sub_id, \
+                            session_id)
+                            
     # set up crash directory
     workflow.config['execution'] = \
         {'crashdump_dir': config["output_directory"]}
-
+    
+    
     # update that resource pool with what's already in the output directory
     for resource in os.listdir(output_dir):
-
-        if os.path.isdir(os.path.join(output_dir, resource)) and resource not in resource_pool.keys():
-
-            resource_pool[resource] = glob.glob(os.path.join(output_dir,
-                                                             resource, "*"))[0]
+    
+        if os.path.isdir(os.path.join(output_dir,resource)) and resource not in resource_pool.keys():
+        
+            resource_pool[resource] = glob.glob(os.path.join(output_dir, \
+                                          resource, "*"))[0]
+                 
 
     # resource pool check
     invalid_paths = []
-
+    
     for resource in resource_pool.keys():
-
+    
         if not os.path.isfile(resource_pool[resource]):
-
+        
             invalid_paths.append((resource, resource_pool[resource]))
-
+            
+            
     if len(invalid_paths) > 0:
-
+        
         err = "\n\n[!] The paths provided in the subject list to the " \
               "following resources are not valid:\n"
-
+        
         for path_tuple in invalid_paths:
-
+        
             err = err + path_tuple[0] + ": " + path_tuple[1] + "\n"
-
+                  
         err = err + "\n\n"
-
+        
         raise Exception(err)
-
+                  
+    
+    
     # start connecting the pipeline
-
+       
     if "qap_functional_temporal" not in resource_pool.keys():
 
         from qap.qap_workflows import qap_functional_temporal_workflow
@@ -132,34 +146,36 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
         workflow, resource_pool = \
             qap_functional_temporal_workflow(workflow, resource_pool, config)
 
+    
+
     # set up the datasinks
     new_outputs = 0
-
+    
     if "write_all_outputs" not in config.keys():
         config["write_all_outputs"] = False
 
     if config["write_all_outputs"] == True:
 
         for output in resource_pool.keys():
-
+    
             # we use a check for len()==2 here to select those items in the
             # resource pool which are tuples of (node, node_output), instead
             # of the items which are straight paths to files
 
             # resource pool items which are in the tuple format are the
             # outputs that have been created in this workflow because they
-            # were not present in the subject list YML (the starting resource
+            # were not present in the subject list YML (the starting resource 
             # pool) and had to be generated
 
             if len(resource_pool[output]) == 2:
-
+    
                 ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
                 ds.inputs.base_directory = output_dir
-
+    
                 node, out_file = resource_pool[output]
 
                 workflow.connect(node, out_file, ds, output)
-
+            
                 new_outputs += 1
 
     else:
@@ -172,26 +188,29 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
 
             ds = pe.Node(nio.DataSink(), name='datasink_%s' % output)
             ds.inputs.base_directory = output_dir
-
+    
             node, out_file = resource_pool[output]
 
             workflow.connect(node, out_file, ds, output)
-
+            
             new_outputs += 1
+         
+    
 
     # run the pipeline (if there is anything to do)
     if new_outputs > 0:
+    
+        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name + \
+                                                          ".dot"), \
+                                                          simple_form=False)
 
-        workflow.write_graph(dotfilename=os.path.join(output_dir, run_name +
-                                                      ".dot"),
-                             simple_form=False)
-
-        workflow.run(plugin='MultiProc', plugin_args={
-                     'n_procs': config["num_cores_per_subject"]})
+        workflow.run(plugin='MultiProc', plugin_args= \
+                         {'n_procs': config["num_cores_per_subject"]})
 
     else:
 
         print "\nEverything is already done for subject %s." % sub_id
+
 
     # Remove working directory when done
     if config["write_all_outputs"] == False:
@@ -205,16 +224,20 @@ def build_functional_temporal_workflow(resource_pool, config, subject_info,
             print "Couldn\'t remove the working directory!"
             pass
 
-    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
 
+    pipeline_end_stamp = strftime("%Y-%m-%d_%H:%M:%S")
+    
     pipeline_end_time = time.time()
 
-    logger.info("Elapsed time (minutes) since last start: %s"
-                % ((pipeline_end_time - pipeline_start_time) / 60))
+    logger.info("Elapsed time (minutes) since last start: %s" \
+                % ((pipeline_end_time - pipeline_start_time)/60))
 
     logger.info("Pipeline end time: %s" % pipeline_end_stamp)
 
+
+
     return workflow
+
 
 
 def run(subject_list, pipeline_config_yaml, cloudify=False):
@@ -224,7 +247,8 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
     from multiprocessing import Process
 
     import time
-
+    
+    
     if not cloudify:
 
         with open(subject_list, "r") as f:
@@ -252,7 +276,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                             resource_dict[resource] = filepath
 
                             sub_info_tuple = (subid, session, scan)
-
+                            
                             if sub_info_tuple not in flat_sub_dict.keys():
                                 flat_sub_dict[sub_info_tuple] = {}
 
@@ -270,14 +294,16 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
                         resource_dict[resource] = filepath
 
                         sub_info_tuple = (subid, session, None)
-
+                        
                         if sub_info_tuple not in flat_sub_dict.keys():
                             flat_sub_dict[sub_info_tuple] = {}
 
-                        flat_sub_dict[sub_info_tuple].update(resource_dict)
+                        flat_sub_dict[sub_info_tuple].update(resource_dict)                
 
-    with open(pipeline_config_yaml, "r") as f:
+        
+    with open(pipeline_config_yaml,"r") as f:
         config = yaml.load(f)
+
 
     try:
         os.makedirs(config["output_directory"])
@@ -289,6 +315,7 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
     try:
         os.makedirs(config["working_directory"])
     except:
@@ -299,65 +326,100 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
         else:
             pass
 
+
+    
     # get the pipeline config file name, use it as the run name
     run_name = pipeline_config_yaml.split("/")[-1].split(".")[0]
 
     if not cloudify:
-
+        
         if len(sites_dict) > 0:
 
-            procss = [Process(target=build_functional_temporal_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, sites_dict[sub_info[0]]))
-                      for sub_info in flat_sub_dict.keys()]
+            procss = [Process(target=build_functional_temporal_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, sites_dict[sub_info[0]])) \
+                                for sub_info in flat_sub_dict.keys()]
 
         elif len(sites_dict) == 0:
 
-            procss = [Process(target=build_functional_temporal_workflow,
-                              args=(flat_sub_dict[sub_info], config, sub_info,
-                                    run_name, None))
-                      for sub_info in flat_sub_dict.keys()]
-
+            procss = [Process(target=build_functional_temporal_workflow, \
+                            args=(flat_sub_dict[sub_info], config, sub_info, \
+                                      run_name, None)) \
+                                for sub_info in flat_sub_dict.keys()]
+                          
+                          
         pid = open(os.path.join(config["output_directory"], 'pid.txt'), 'w')
-
+    
         # Init job queue
         job_queue = []
-        ns_atonce = config.get('num_subjects_at_once', 1)
 
-        # Stream the subject workflows for preprocessing.
-        # At Any time in the pipeline c.numSubjectsAtOnce
-        # will run, unless the number remaining is less than
-        # the value of the parameter stated above
+        # If we're allocating more processes than are subjects, run them all
+        if len(flat_sub_dict) <= config["num_subjects_at_once"]:
+    
+            """
+            Stream all the subjects as sublist is
+            less than or equal to the number of 
+            subjects that need to run
+            """
+    
+            for p in procss:
+                p.start()
+                print >>pid,p.pid
+    
+        # Otherwise manage resources to run processes incrementally
+        else:
+    
+            """
+            Stream the subject workflows for preprocessing.
+            At Any time in the pipeline c.numSubjectsAtOnce
+            will run, unless the number remaining is less than
+            the value of the parameter stated above
+            """
+    
+            idx = 0
+    
+            while(idx < len(flat_sub_dict)):
+    
+                # If the job queue is empty and we haven't started indexing
+                if len(job_queue) == 0 and idx == 0:
+    
+                    # Init subject process index
+                    idc = idx
+    
+                    # Launch processes (one for each subject)
+                    for p in procss[idc: idc+config["num_subjects_at_once"]]:
+    
+                        p.start()
+                        print >>pid,p.pid
+                        job_queue.append(p)
+                        idx += 1
+    
+                # Otherwise, jobs are running - check them
+                else:
+    
+                    # Check every job in the queue's status
+                    for job in job_queue:
+    
+                        # If the job is not alive
+                        if not job.is_alive():
+    
+                            # Find job and delete it from queue
+                            print 'found dead job ', job
+                            loc = job_queue.index(job)
+                            del job_queue[loc]
+    
+                            # ..and start the next available process (subject)
+                            procss[idx].start()
+    
+                            # Append this to job queue and increment index
+                            job_queue.append(procss[idx])
+                            idx += 1
 
-        idx = 0
-        nprocs = len(procss)
-        while idx < nprocs:
-            # Check every job in the queue's status
-            for job in job_queue:
-                # If the job is not alive
-                if not job.is_alive():
-                    # Find job and delete it from queue
-                    logger.info('found dead job: %s' % str(job))
-                    loc = job_queue.index(job)
-                    del job_queue[loc]
-
-            # Check free slots after prunning jobs
-            slots = ns_atonce - len(job_queue)
-
-            if slots > 0:
-                idc = idx
-                for p in procss[idc:idc + slots]:
-                    # ..and start the next available process (subject)
-                    p.start()
-                    print >>pid, p.pid
-                    # Append this to job queue and increment index
-                    job_queue.append(p)
-                    idx += 1
-
-            # Add sleep so while loop isn't consuming 100% of CPU
-            time.sleep(2)
-
+                    # Add sleep so while loop isn't consuming 100% of CPU
+                    time.sleep(2)
+    
         pid.close()
+
 
     else:
 
@@ -372,9 +434,10 @@ def run(subject_list, pipeline_config_yaml, cloudify=False):
 
         filesplit = filepath.split(config["bucket_prefix"])
         site_name = filesplit[1].split("/")[1]
+        
+        build_functional_temporal_workflow(subject_list[sub], config, sub, \
+                                               run_name, site_name)
 
-        build_functional_temporal_workflow(subject_list[sub], config, sub,
-                                           run_name, site_name)
 
 
 def main():
@@ -385,26 +448,30 @@ def main():
 
     group = parser.add_argument_group("Regular Use Inputs (non-cloud runs)")
 
-    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "
+    cloudgroup = parser.add_argument_group("AWS Cloud Inputs (only required "\
                                            "for AWS Cloud runs)")
 
     req = parser.add_argument_group("Required Inputs")
 
-    cloudgroup.add_argument('--subj_idx', type=int,
-                            help='Subject index to run')
 
-    cloudgroup.add_argument('--s3_dict_yml', type=str,
-                            help='Path to YAML file containing S3 input '
-                            'filepaths dictionary')
+    cloudgroup.add_argument('--subj_idx', type=int, \
+                                help='Subject index to run')
+
+    cloudgroup.add_argument('--s3_dict_yml', type=str, \
+                                help='Path to YAML file containing S3 input '\
+                                     'filepaths dictionary')
+
 
     # Subject list (YAML file)
-    group.add_argument("--sublist", type=str,
-                       help="filepath to subject list YAML")
+    group.add_argument("--sublist", type=str, \
+                            help="filepath to subject list YAML")
 
-    req.add_argument("config", type=str,
-                     help="filepath to pipeline configuration YAML")
+    req.add_argument("config", type=str, \
+                            help="filepath to pipeline configuration YAML")
+
 
     args = parser.parse_args()
+
 
     # checks
     if args.subj_idx and not args.s3_dict_yml and not args.sublist:
@@ -438,8 +505,8 @@ def main():
             from qap.cloud_utils import dl_subj_from_s3, upl_qap_output
 
             # Download and build a one-subject dictionary from S3
-            sub_dict = dl_subj_from_s3(args.subj_idx, args.config,
-                                       args.s3_dict_yml)
+            sub_dict = dl_subj_from_s3(args.subj_idx, args.config, \
+                                           args.s3_dict_yml)
 
             if not sub_dict:
                 err = "\n[!] Subject dictionary was not successfully " \
@@ -452,11 +519,16 @@ def main():
             # Upload results
             upl_qap_output(args.config)
 
+
         elif args.sublist:
 
             # Run it
             run(args.sublist, args.config, cloudify=False)
 
 
+
 if __name__ == "__main__":
     main()
+
+
+    


### PR DESCRIPTION
This PR fixes #12 , simplifying the convoluted loop there was to start processes.

The current schedulers are designed in two parts:
1. If there are less subjects than slots, launch all processes right away.
2. Else launch processes until the slots are run out. After that check every 2 secs if any process finished, and if so liberate a slot and run the next process.

The PR simplifies this, and is robust (fixes #12). The only practical difference is that using the former scheduler only the fist `config["num_subjects_at_once"]` times 2 processes are written into the pid file. I don't know if this was a feature, but I considered it as a bug. Now every process is introduced in the pid file. It can be easily changed by stop writing the pid after the first `config["num_subjects_at_once"]` times 2.
