### PR TITLE
[FIX] Add qap.viz to modules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def main():
           download_url='https://github.com/preprocessed-connectomes-project/'\
                        'quality-assessment-protocol/tarball/1.0.2',
           license='',
-          packages=['qap'],
+          packages=['qap', 'qap.viz'],
           package_data={'qap': ['inpoint*.txt',
                                 'test_data/*.nii.gz',
                                 'test_data/workflow_reference/*/*',


### PR DESCRIPTION
This PR fixes #26.

Using the pip version the following command fails: `python -c "from qap.viz.interfaces import PlotMosaic"`

I have tested the pip installation from this branch:

```
pip install git+https://github.com/oesteban/quality-assessment-protocol.git@fix/issue-26
```

And the problem is apparently fixed.
